### PR TITLE
Move Continue button after the response text

### DIFF
--- a/apps/interactor/src/components/chat-box/ResponseBox.scss
+++ b/apps/interactor/src/components/chat-box/ResponseBox.scss
@@ -72,8 +72,7 @@
 
   &__regenerate,
   &__voice,
-  &__edit,
-  &__continue {
+  &__edit {
     transition: all 0.2s ease-out;
     display: inline-flex;
     align-items: center;
@@ -156,6 +155,30 @@
 
     &:hover {
       color: lightgray;
+    }
+  }
+
+  &__continue {
+    color: white;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    margin-left: 0.5rem;
+    font-size: 1rem;
+    opacity: 0;
+    transition: all 0.2s ease-out;
+    text-transform: lowercase;
+    font-variant: small-caps;
+    position: relative;
+    top: -1px;
+
+    &:hover {
+      opacity: 0.8;
+      text-shadow: 0 0 6px white;
+    }
+
+    svg {
+      font-size: 0.8rem;
     }
   }
 }

--- a/apps/interactor/src/components/chat-box/ResponseBox.tsx
+++ b/apps/interactor/src/components/chat-box/ResponseBox.tsx
@@ -78,7 +78,7 @@ const ResponseBox = (): JSX.Element | null => {
     })
     dispatch(
       continueResponse({
-        servicesEndpoint
+        servicesEndpoint,
       })
     )
   }
@@ -110,27 +110,33 @@ const ResponseBox = (): JSX.Element | null => {
         {isLastResponseFetching ? (
           <TextFormatterStatic text="*Typing...*" />
         ) : (
-          <TextFormatter text={displayText} />
+          <TextFormatter
+            text={displayText}
+            children={
+              !disabled ? (
+                <button
+                  className="ResponseBox__continue"
+                  onClick={handleContinueClick}
+                >
+                  continue
+                  <FaForward />
+                </button>
+              ) : null
+            }
+          />
         )}
       </div>
       <div className="ResponseBox__actions">
         {!disabled ? <TTSPlayer /> : null}
         {!disabled &&
-          lastReponse?.parentInteractionId &&
-          (swipes?.length || 0) < 8 ? (
+        lastReponse?.parentInteractionId &&
+        (swipes?.length || 0) < 8 ? (
           <button
             className="ResponseBox__regenerate"
             onClick={handleRegenerateClick}
           >
             <FaDice />
             <span>Regenerate</span>
-          </button>
-        ) : null}
-        {!disabled &&
-          lastReponse?.parentInteractionId ? (
-          <button className="ResponseBox__continue" onClick={handleContinueClick}>
-            <FaForward />
-            <span>Continue</span>
           </button>
         ) : null}
         {!disabled && !isInteractionDisabled ? (
@@ -146,8 +152,9 @@ const ResponseBox = (): JSX.Element | null => {
             if (!swipe?.id) return null
             return (
               <button
-                className={`ResponseBox__swipe ${lastReponse?.id === swipe.id ? 'selected' : ''
-                  }`}
+                className={`ResponseBox__swipe ${
+                  lastReponse?.id === swipe.id ? 'selected' : ''
+                }`}
                 key={`swipe-${swipe.id}`}
                 onClick={() => dispatch(swipeResponse(swipe.id))}
                 disabled={disabled}

--- a/apps/interactor/src/components/common/TextFormatter.tsx
+++ b/apps/interactor/src/components/common/TextFormatter.tsx
@@ -6,9 +6,13 @@ import classNames from 'classnames'
 
 interface TextFormatterProps {
   text: string
+  children?: React.ReactNode
 }
 
-export const TextFormatterStatic: React.FC<TextFormatterProps> = ({ text }) => {
+export const TextFormatterStatic: React.FC<TextFormatterProps> = ({
+  text,
+  children,
+}) => {
   const fontSize = useAppSelector((state) => state.settings.text.fontSize)
   const textFormatterDiv = React.useRef<HTMLDivElement>(null)
   const [userScrolled, setUserScrolled] = useState(false)
@@ -102,6 +106,7 @@ export const TextFormatterStatic: React.FC<TextFormatterProps> = ({ text }) => {
       }}
     >
       {elements}
+      {children}
     </div>
   )
 }
@@ -113,7 +118,7 @@ const SpeedToMs = new Map<Speed, number>([
   [Speed.Slow, 30],
 ])
 
-const TextFormatter: React.FC<TextFormatterProps> = ({ text }) => {
+const TextFormatter: React.FC<TextFormatterProps> = ({ text, children }) => {
   const [displayedText, setDisplayedText] = useState('')
   const [currentIndex, setCurrentIndex] = useState(0)
   const speed = useAppSelector((state) => state.settings.text.speed)
@@ -141,7 +146,12 @@ const TextFormatter: React.FC<TextFormatterProps> = ({ text }) => {
     }
   }, [currentIndex, text, speed])
 
-  return <TextFormatterStatic text={displayedText} />
+  return (
+    <TextFormatterStatic
+      text={displayedText}
+      children={displayedText === text ? children : null}
+    />
+  )
 }
 
 export default TextFormatter

--- a/apps/interactor/src/state/slices/narrationSlice.ts
+++ b/apps/interactor/src/state/slices/narrationSlice.ts
@@ -197,8 +197,8 @@ const narrationSlice = createSlice({
         : null
       if (!lastResponse) return state
 
-      const continuationTokens = ['\n"', '\n*', '\n*{{char}}']
-      const endingTokens = ['\n', '*', '"', '.']
+      const continuationTokens = ['\n"', '\n*', '\n"{{user}},', '\n*{{char}}']
+      const endingTokens = ['\n', '*', '"', '.', '?', '!']
       if (endingTokens.some((token) => lastResponse.text.endsWith(token))) {
         lastResponse.text =
           trim(lastResponse.text) +


### PR DESCRIPTION
When you hover, it shows the continue button after the response text
![image](https://github.com/miku-gg/miku/assets/124639231/1ae37013-e718-41a1-862d-c7ca98de88a3)
